### PR TITLE
feat: 동별 통계 API 추가

### DIFF
--- a/src/controllers/reviewController.ts
+++ b/src/controllers/reviewController.ts
@@ -299,7 +299,7 @@ export class ReviewController {
         cursor, 
         location, 
         analysisMethod, 
-        safetyLevel 
+        safetyLevel
       } = req.query;
 
       const limitNum = parseInt(limit as string);
@@ -502,6 +502,35 @@ export class ReviewController {
     }
 
     return recommendations.length > 0 ? recommendations : ['현재 안전 상태가 양호합니다.'];
+  }
+
+  // 동별 통계 조회
+  async getLocationStats(req: Request, res: Response) {
+    try {
+      const { location } = req.query;
+
+      if (!location || typeof location !== 'string') {
+        return res.status(400).json({
+          success: false,
+          error: '지역 정보가 필요합니다.'
+        });
+      }
+
+      const stats = await ReviewService.getLocationStats(location);
+
+      res.json({
+        success: true,
+        data: stats
+      });
+      return;
+
+    } catch (error) {
+      console.error('Error in getLocationStats:', error);
+      return res.status(500).json({
+        success: false,
+        error: '동별 통계 조회 중 오류가 발생했습니다.'
+      });
+    }
   }
 
   // 사용 가능한 키워드 목록 조회

--- a/src/routes/reviewRoutes.ts
+++ b/src/routes/reviewRoutes.ts
@@ -53,9 +53,14 @@ router.delete('/:id', (req, res) => {
   reviewController.deleteReview(req, res);
 });
 
-// 통계 정보 조회
+// 전체 통계 정보 조회
 router.get('/stats/summary', (req, res) => {
   reviewController.getReviewStats(req, res);
+});
+
+// 동별 통계 조회
+router.get('/stats/location', (req, res) => {
+  reviewController.getLocationStats(req, res);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
  동네별 리뷰 키워드 통계를 조회할 수 있는 API를 구현했습니다. 특정 지역(동 단위)의 평균 평점, 총 리뷰 수, 상위 키워드 통계를 제공하여 지역별 안전도 분석이 가능합니다.

  ## Changes
  📊 **동별 통계 API 구현**
  - 지역별 리뷰 통계 조회 기능 추가 (`/api/review/stats/location`)
  - ReviewService에 `getLocationStats` 메소드 구현
  - 평균 평점, 총 리뷰 수, 상위 키워드 3개 통계 제공
  - 키워드 사용 빈도 및 백분율 계산 기능

  🎯 **키워드 통계 최적화**
  - 프론트엔드 UI 키워드 형식으로 통계 반환
  - 카테고리별 키워드 집계 및 순위 정렬
  - 정확한 키워드 매핑 보장

  ## Test Instructions
  ```bash
  # 동별 통계 조회 테스트
  curl "http://localhost:3001/api/review/stats/location?location=역삼동"

  # 결과 예시:
   {
     "success": true,
     "data": {
     "location": "역삼동",
     "averageRating": 3.8,
     "totalReviews": 10,
      "topKeywords": [
           {"keyword": "밤에도 밝아요", "count": 6, "percentage": 60},
           {"keyword": "늦게까지 여는 가게 있어요", "count": 1, "percentage": 10},
           {"keyword": "순찰차가 자주 돌아요", "count": 1, "percentage": 10}
        ]
     }
   }
```
  API Endpoints

  - GET /api/review/stats/location?location={동이름} - 동별 통계 조회

  Features

  - 지역별 평균 평점 계산
  - 총 리뷰 수 집계
  - 상위 키워드 3개 선정 (빈도순)
  - 키워드별 사용 백분율 제공
  - 프론트엔드 키워드 형식 호환