### PR TITLE
fix: posts 테이블 초기 스크립트에 views 컬럼 누락 수정

### DIFF
--- a/init-scripts/001-create-posts-table.sql
+++ b/init-scripts/001-create-posts-table.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS posts (
     status VARCHAR(20) DEFAULT 'recruiting' CHECK (status IN ('recruiting', 'active', 'full')),
     
     -- Common fields
+    views INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     
@@ -43,3 +44,4 @@ CREATE INDEX IF NOT EXISTS idx_posts_created_at ON posts(created_at);
 CREATE INDEX IF NOT EXISTS idx_posts_date ON posts(date) WHERE category != '일반';
 CREATE INDEX IF NOT EXISTS idx_posts_location ON posts(location) WHERE category != '일반';
 CREATE INDEX IF NOT EXISTS idx_posts_status ON posts(status) WHERE category != '일반';
+CREATE INDEX IF NOT EXISTS idx_posts_views ON posts(views);


### PR DESCRIPTION
  - 001-create-posts-table.sql에 views INTEGER DEFAULT 0 컬럼 추가
  - views 컬럼용 인덱스 추가
  - 새 환경 구축 시 "column p.views does not exist" 에러 해결