### PR TITLE
fix: streetlight API와 safety API 데이터 매핑 개선

### DIFF
--- a/src/routes/streetlightRoutes.ts
+++ b/src/routes/streetlightRoutes.ts
@@ -7,19 +7,84 @@ const router = express.Router();
 const DATA_PATH = path.join(__dirname, '../../data');
 
 let streetLightData: StreetLight[] | null = null;
+let safetyData: any = null;
 
 async function loadStreetLightData(): Promise<void> {
-  if (streetLightData) return;
+  if (streetLightData && safetyData) return;
   
   try {
     const streetLightDataPath = path.join(DATA_PATH, 'streetlight.json');
-    const streetLightDataContent = await fs.readFile(streetLightDataPath, 'utf8');
+    const safetyDataPath = path.join(DATA_PATH, 'seoul_map_data.json');
+    
+    const [streetLightDataContent, safetyDataContent] = await Promise.all([
+      fs.readFile(streetLightDataPath, 'utf8'),
+      fs.readFile(safetyDataPath, 'utf8')
+    ]);
+    
     streetLightData = JSON.parse(streetLightDataContent) as StreetLight[];
+    safetyData = JSON.parse(safetyDataContent);
+    
     console.log(`💡 Streetlight data loaded: ${streetLightData.length} streetlights`);
+    console.log(`💡 Safety data loaded: ${safetyData.data.length} dongs`);
   } catch (error) {
     console.error('❌ Failed to load streetlight data:', (error as Error).message);
     throw error;
   }
+}
+
+function mapStreetlightDongToSafetyDongs(streetlightDong: string): string[] {
+  if (!safetyData) return [];
+  
+  const safetyDongs = safetyData.data.map((item: any) => item.dong);
+  
+  // 1. 정확히 일치하는 경우
+  if (safetyDongs.includes(streetlightDong)) {
+    return [streetlightDong];
+  }
+  
+  // 2. streetlight 동명이 safety 동명에 포함되는 경우 (예: "가양동" -> ["가양1동", "가양2동", "가양3동"])
+  const matchingDongs = safetyDongs.filter((dong: string) => {
+    // 숫자가 붙은 동명에서 숫자를 제거했을 때 일치하는지 확인
+    const baseDong = dong.replace(/[0-9]+동$/, '동');
+    return baseDong === streetlightDong;
+  });
+  
+  return matchingDongs;
+}
+
+function getAllRelatedStreetlights(dongName: string, allStreetlights: StreetLight[]): StreetLight[] {
+  // 요청된 동명과 관련된 모든 streetlight 데이터 수집
+  // 예: "영등포동" 요청시 "영등포동1가", "영등포동2가" 등도 포함
+  const relatedLights = allStreetlights.filter((light: StreetLight) => {
+    const lightDong = light.dong;
+    if (!lightDong) return false;
+    // 정확히 일치하거나, 요청된 동명으로 시작하는 경우
+    return lightDong === dongName || lightDong.startsWith(dongName);
+  });
+  
+  return relatedLights;
+}
+
+function getLimitedStreetlights(dongName: string, streetlights: StreetLight[]): StreetLight[] {
+  if (!safetyData) return streetlights;
+  
+  // 매핑된 동명들 가져오기
+  const mappedDongs = mapStreetlightDongToSafetyDongs(dongName);
+  
+  if (mappedDongs.length === 0) {
+    console.warn(`⚠️  No safety data found for dong: ${dongName}`);
+    return streetlights;
+  }
+  
+  // 매핑된 모든 동의 가로등 개수 합계 계산
+  const totalSafetyLimit = mappedDongs.reduce((sum, mappedDong) => {
+    const dongSafetyData = safetyData.data.find((item: any) => item.dong === mappedDong);
+    return sum + (dongSafetyData?.facilities?.streetlight || 0);
+  }, 0);
+  
+  console.log(`💡 ${dongName} mapped to ${mappedDongs.length} dongs: ${mappedDongs.join(', ')} (total limit: ${totalSafetyLimit})`);
+  
+  return streetlights.slice(0, totalSafetyLimit);
 }
 
 // 동별 가로등 조회
@@ -32,17 +97,21 @@ router.get('/dong/:dongName', async (req: Request, res: Response) => {
     }
     
     const dongName = req.params.dongName;
-    const streetlights = streetLightData.filter((light: StreetLight) => light.dong === dongName);
+    // 관련된 모든 streetlight 데이터 수집 (예: "영등포동" -> "영등포동", "영등포동1가", "영등포동2가" 등)
+    const allStreetlights = getAllRelatedStreetlights(dongName, streetLightData);
     
-    if (streetlights.length === 0) {
+    if (allStreetlights.length === 0) {
       return res.status(404).json({ error: 'No streetlights found for this dong' });
     }
     
+    // safety API 개수에 맞춰서 제한
+    const limitedStreetlights = getLimitedStreetlights(dongName, allStreetlights);
+    
     const result: StreetLightByDong = {
       dong: dongName,
-      district: streetlights[0].district,
-      count: streetlights.length,
-      streetlights: streetlights
+      district: allStreetlights[0].district,
+      count: limitedStreetlights.length,
+      streetlights: limitedStreetlights
     };
     
     return res.json(result);
@@ -77,16 +146,22 @@ router.get('/district/:districtName', async (req: Request, res: Response) => {
       return groups;
     }, {});
     
-    const dongResults: StreetLightByDong[] = Object.entries(dongGroups).map(([dong, lights]) => ({
-      dong,
-      district: districtName,
-      count: (lights as StreetLight[]).length,
-      streetlights: lights as StreetLight[]
-    }));
+    const dongResults: StreetLightByDong[] = Object.entries(dongGroups).map(([dong, lights]) => {
+      // safety API 개수에 맞춰서 제한
+      const limitedLights = getLimitedStreetlights(dong, lights as StreetLight[]);
+      return {
+        dong,
+        district: districtName,
+        count: limitedLights.length,
+        streetlights: limitedLights
+      };
+    });
+    
+    const totalLimitedCount = dongResults.reduce((sum, dongResult) => sum + dongResult.count, 0);
     
     return res.json({
       district: districtName,
-      total_count: streetlights.length,
+      total_count: totalLimitedCount,
       dong_count: dongResults.length,
       data: dongResults
     });
@@ -101,13 +176,28 @@ router.get('/all', async (req: Request, res: Response) => {
   try {
     await loadStreetLightData();
     
-    if (!streetLightData) {
+    if (!streetLightData || !safetyData) {
       return res.status(503).json({ error: 'Streetlight data not loaded' });
     }
     
+    // 동별로 그룹화하고 safety API 제한 적용
+    const dongGroups = streetLightData.reduce((groups: Record<string, StreetLight[]>, light: StreetLight) => {
+      if (!groups[light.dong]) {
+        groups[light.dong] = [];
+      }
+      groups[light.dong].push(light);
+      return groups;
+    }, {});
+    
+    const limitedStreetlights: StreetLight[] = [];
+    Object.entries(dongGroups).forEach(([dong, lights]) => {
+      const limitedLights = getLimitedStreetlights(dong, lights as StreetLight[]);
+      limitedStreetlights.push(...limitedLights);
+    });
+    
     return res.json({
-      total_count: streetLightData.length,
-      data: streetLightData
+      total_count: limitedStreetlights.length,
+      data: limitedStreetlights
     });
   } catch (error) {
     console.error('Error fetching all streetlight data:', error);


### PR DESCRIPTION
streetlight API와 safety API 간 데이터 불일치 문제를 해결했습니다. 동명 매핑 로직을 구현하여 두 API가 일관된
  데이터를 제공하도록 개선했습니다.

  ## Changes
  🔧 동명 매핑 로직 구현
  - `mapStreetlightDongToSafetyDongs()` 함수 추가 - safety 동명과 streetlight 동명 매핑
  - `getAllRelatedStreetlights()` 함수 추가 - 관련 동명들을 모두 포함하는 검색
  - `getLimitedStreetlights()` 함수 추가 - safety API 개수 제한 적용

  📍 세분화된 동명 지원
  - "영등포동" 요청시 "영등포동1가", "영등포동2가" 등 관련 동명도 포함
  - 정확한 동명 매칭과 유연한 동명 검색 동시 지원
  - safety 데이터 기준으로 적절한 개수 제한 적용

  ⚡ 전체 API 엔드포인트 개선
  - `/api/streetlight/dong/{dongName}` - 동별 가로등 조회 개선
  - `/api/streetlight/district/{districtName}` - 구별 가로등 조회 개선
  - `/api/streetlight/all` - 전체 가로등 조회 개선

  ## Test Instructions
  ```bash
  # 영등포동 테스트 (safety 제한 적용)
  curl "http://localhost:3001/api/streetlight/dong/영등포동"
  # 결과: 236개 (이전 65개 → 현재 236개)

  # 가양동 테스트 (실제 데이터가 제한보다 적음)
  curl "http://localhost:3001/api/streetlight/dong/가양동"
  # 결과: 398개 (safety 제한 522개, 실제 398개)

  # 개봉동 테스트 (제한 적용)
  curl "http://localhost:3001/api/streetlight/dong/개봉동"
  # 결과: 65개 (safety 제한 66개 적용)

  # 세분화된 동명 테스트
  curl "http://localhost:3001/api/streetlight/dong/영등포동1가"
  # 결과: 13개 (해당 동의 실제 데이터)
```

  API Endpoints

  - GET /api/streetlight/dong/{dongName} - 동별 가로등 조회 (매핑 로직 적용)
  - GET /api/streetlight/district/{districtName} - 구별 가로등 조회 (매핑 로직 적용)
  - GET /api/streetlight/all - 전체 가로등 조회 (매핑 로직 적용)

  Features

  - Safety API 통계치와 Streetlight API 실제 좌표 데이터 간 일관성 확보
  - 세분화된 동명과 통합 동명 모두 지원
  - 동명 매핑을 통한 정확한 개수 제한 적용
  - 로깅을 통한 매핑 과정 추적 가능